### PR TITLE
Remove outdated zig warning

### DIFF
--- a/docs/codelabs/zig/index.html
+++ b/docs/codelabs/zig/index.html
@@ -92,8 +92,6 @@ THEN discount the order by Z%
 </code></pre>
 </google-codelab-step>
 <google-codelab-step label="Test your function on Shopify" duration="0">
-<aside class="warning"><p> Zig WASI executables currently will not sucessfully execute on Shopify. </p>
-</aside>
 <p>Use the following steps, selecting the <code>order-discount-zig</code> discount type, and using <code>ZIG</code> as your discount code.</p>
 <h2 is-upgraded>Testing a discount on Shopify</h2>
 <ol type="1">

--- a/workshop/codelabs/zig.md
+++ b/workshop/codelabs/zig.md
@@ -91,10 +91,6 @@ error while executing at wasm backtrace:
 
 ## Test your function on Shopify
 
-<aside class="negative">
-Zig WASI executables currently will not sucessfully execute on Shopify.
-</aside>
-
 Use the following steps, selecting the `order-discount-zig` discount type, and using `ZIG` as your discount code.
 
 <<include/test-shopify.md>>


### PR DESCRIPTION
Now that the bug in Shopify Functions' Wasm runtime is fixed, we can remove this warning.